### PR TITLE
Add message and error code in QR response

### DIFF
--- a/generic_authenticator_qr_request.go
+++ b/generic_authenticator_qr_request.go
@@ -10,17 +10,18 @@ import (
 type GenericAuthenticatorQRRequest struct {
 	HTTPResponse *http.Response
 
-	Label   string `json:"label"`
-	Issuer  string `json:"issuer"`
-	QRCode  string `json:"qr_code"`
-	Success bool   `json:"success"`
+	ErrorCode    string `json:"error_code"`
+	ErrorMessage string `json:"message"`
+	Label        string `json:"label"`
+	Issuer       string `json:"issuer"`
+	QRCode       string `json:"qr_code"`
+	Success      bool   `json:"success"`
 }
 
 // NewGenericAuthenticatorQR creates an instance of a GenericAuthenticatorQRRequest
 func NewGenericAuthenticatorQR(response *http.Response) (*GenericAuthenticatorQRRequest, error) {
 	genericAuthenticatorQR := &GenericAuthenticatorQRRequest{HTTPResponse: response}
 	body, err := ioutil.ReadAll(response.Body)
-
 	if err != nil {
 		Logger.Println("Error reading from API:", err)
 		return genericAuthenticatorQR, err

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/rainhq/go-authy
+
+go 1.17
+
+require (
+	github.com/gojektech/heimdall v5.0.0+incompatible
+	github.com/stretchr/testify v1.2.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gojektech/valkyrie v0.0.0-20180215180059-6aee720afcdf // indirect
+	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gojektech/heimdall v5.0.0+incompatible h1:FDgMItzHNG5BdXQE2tLpoPR0B1XUAO0wu0hxeJ/BYeI=
+github.com/gojektech/heimdall v5.0.0+incompatible/go.mod h1:8hRIZ3+Kz0r3GAFI9QrUuvZht8ypg5Rs8schCXioLOo=
+github.com/gojektech/valkyrie v0.0.0-20180215180059-6aee720afcdf h1:WUa/Tvd+vZuW17gOND3CryHvG0yc2nhC1gr+H2F7bFM=
+github.com/gojektech/valkyrie v0.0.0-20180215180059-6aee720afcdf/go.mod h1:tDYRk1s5Pms6XJjj5m2PxAzmQvaDU8GqDf1u6x7yxKw=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
## Description:
Add `ErrorCode` and `ErrorMessage` in `GenericAuthenticatorQRRequest`, since this is the response struct and the Authy's response unmarshal on this struct when the request succeeded or failed. I did that for logging the error message in the Rain codebase.